### PR TITLE
feat: add web-app to docker-compose and update scripts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,5 +73,25 @@ services:
     profiles:
       - backend
 
+  web-app:
+    build:
+      context: ./AcctAtlas-web-app
+      dockerfile: Dockerfile
+    ports:
+      - "3000:3000"
+    environment:
+      NEXT_PUBLIC_API_URL: http://localhost:8080/api/v1
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    depends_on:
+      api-gateway:
+        condition: service_started
+    profiles:
+      - frontend
+
 volumes:
   postgres_data:


### PR DESCRIPTION
## Summary

Adds web-app service to docker-compose.yml and updates startup/stop scripts for fully containerized development.

## Changes

- **docker-compose.yml**: Add `web-app` service with `frontend` profile, builds from `./AcctAtlas-web-app/Dockerfile`
- **docker-start.sh**: Use both `--profile backend --profile frontend`, remove npm-based web-app startup
- **docker-stop.sh**: Use both profiles, remove `--all` flag (no longer needed)

## Dependencies

Requires AcctAtlas-web-app PR #6 (Docker support) to be merged first.

## Test plan

- [x] `./scripts/docker-start.sh` starts all services in containers
- [x] `./scripts/docker-stop.sh` stops all containers
- [x] E2E tests pass against containerized stack

🤖 Generated with [Claude Code](https://claude.ai/code)