### PR TITLE
feat: add location-service to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # Local development only - do not use these credentials in production
 services:
   postgres:
-    image: postgres:17-alpine
+    image: postgis/postgis:17-3.5-alpine
     ports:
       - "5432:5432"
     environment:
@@ -51,6 +51,31 @@ services:
       postgres:
         condition: service_healthy
       redis:
+        condition: service_healthy
+    profiles:
+      - backend
+
+  location-service:
+    image: acctatlas/location-service:latest
+    ports:
+      - "8083:8083"
+    environment:
+      SPRING_PROFILES_ACTIVE: docker
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/location_service
+      SPRING_DATASOURCE_USERNAME: location_service
+      SPRING_DATASOURCE_PASSWORD: local_dev  # dev-only
+      SPRING_FLYWAY_URL: jdbc:postgresql://postgres:5432/location_service
+      SPRING_FLYWAY_USER: location_service
+      SPRING_FLYWAY_PASSWORD: local_dev  # dev-only
+      MAPBOX_ACCESS_TOKEN: ${MAPBOX_ACCESS_TOKEN:-}
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8083/actuator/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    depends_on:
+      postgres:
         condition: service_healthy
     profiles:
       - backend

--- a/docker/postgres/init-databases.sql
+++ b/docker/postgres/init-databases.sql
@@ -11,3 +11,12 @@ GRANT ALL PRIVILEGES ON DATABASE user_service TO user_service;
 -- Connect to user_service database to set up schema permissions
 \c user_service
 GRANT ALL ON SCHEMA public TO user_service;
+
+-- Location Service database
+CREATE USER location_service WITH PASSWORD 'local_dev';  -- dev-only password
+CREATE DATABASE location_service OWNER location_service;
+GRANT ALL PRIVILEGES ON DATABASE location_service TO location_service;
+
+\c location_service
+CREATE EXTENSION IF NOT EXISTS postgis;
+GRANT ALL ON SCHEMA public TO location_service;


### PR DESCRIPTION
## Summary

- Update postgres image to `postgis/postgis:17-3.5-alpine` for PostGIS support
- Add location_service database to postgres init script
- Add location-service container to docker-compose

## Changes

- `docker/postgres/init-databases.sql` - Add location_service database with PostGIS extension
- `docker-compose.yml` - Add location-service container with proper environment config

## Test plan

- [x] `docker-compose up postgres` starts with PostGIS
- [x] `docker-compose --profile backend up` starts location-service
- [x] Location-service health check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)