### PR TITLE
fix: add missing service URLs to api-gateway docker-compose config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -200,7 +200,10 @@ services:
     environment:
       SPRING_PROFILES_ACTIVE: docker
       USER_SERVICE_URL: http://user-service:8081
+      VIDEO_SERVICE_URL: http://video-service:8082
+      LOCATION_SERVICE_URL: http://location-service:8083
       SEARCH_SERVICE_URL: http://search-service:8084
+      MODERATION_SERVICE_URL: http://moderation-service:8085
       # Uses custom placeholders in application.yml (not standard Spring binding)
       REDIS_HOST: redis
       REDIS_PORT: 6379


### PR DESCRIPTION
## Summary

- Add missing `VIDEO_SERVICE_URL`, `LOCATION_SERVICE_URL`, and `MODERATION_SERVICE_URL` environment variables to the api-gateway service in docker-compose.yml

## Problem

When running the full stack with `docker-compose --profile backend up`, requests to video, location, and moderation services failed with `500 Internal Server Error`. 

The gateway was using default `localhost` URLs from `application.yml`, but inside Docker, `localhost` refers to the container itself, not the host machine or other containers.

## Solution

Add explicit environment variables pointing to the Docker network hostnames:

```yaml
VIDEO_SERVICE_URL: http://video-service:8082
LOCATION_SERVICE_URL: http://location-service:8083
MODERATION_SERVICE_URL: http://moderation-service:8085
```

## Test plan

- [x] Run `docker-compose --profile backend --profile frontend up -d`
- [x] Verify all services healthy
- [x] Run API integration tests: `npm run test:api` (40 passed)
- [x] Run E2E tests: `npm run test:e2e` (9 passed)

Fixes #27

Generated with [Claude Code](https://claude.com/claude-code)