### PR TITLE
fix: add healthcheck and service dependencies to api-gateway

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -207,8 +207,22 @@ services:
       # Uses custom placeholders in application.yml (not standard Spring binding)
       REDIS_HOST: redis
       REDIS_PORT: 6379
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/actuator/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
     depends_on:
       user-service:
+        condition: service_healthy
+      video-service:
+        condition: service_healthy
+      location-service:
+        condition: service_healthy
+      search-service:
+        condition: service_healthy
+      moderation-service:
         condition: service_healthy
       redis:
         condition: service_healthy


### PR DESCRIPTION
## Summary

The api-gateway was starting before all backend services were healthy, causing intermittent test failures in CI when routing to services that weren't ready yet.

## Changes

- Add healthcheck to api-gateway (actuator/health endpoint)
- Add `depends_on` for all backend services (video, location, search, moderation) with `service_healthy` condition

## Why

The integration tests workflow uses `docker compose --wait` which only waits for services with healthchecks. Without a healthcheck on api-gateway, and without dependencies on the other backend services, the gateway could start routing requests to unhealthy services.

## Test plan

- [ ] Run `docker compose --profile backend up -d --wait` and verify all services are healthy before the command returns
- [ ] Run integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)