### PR TITLE
feat: pass Mapbox token to web-app Docker build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -233,10 +233,14 @@ services:
     build:
       context: ./AcctAtlas-web-app
       dockerfile: Dockerfile
+      args:
+        NEXT_PUBLIC_API_URL: http://localhost:8080/api/v1
+        NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN: ${NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN:-}
     ports:
       - "3000:3000"
     environment:
       NEXT_PUBLIC_API_URL: http://localhost:8080/api/v1
+      NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN: ${NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN:-}
     healthcheck:
       test: ["CMD", "node", "-e", "require('http').get('http://localhost:3000', (r) => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"]
       interval: 10s


### PR DESCRIPTION
## Summary
- Pass `NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN` as a Docker build argument to web-app
- Next.js requires `NEXT_PUBLIC_*` variables at build time for client-side code inlining
- Fixes E2E test failures caused by "Mapbox token not configured" errors

## Test plan
- [x] Run `docker-compose --profile frontend build` with `.env` containing the token
- [x] Verify map page loads without "Mapbox token not configured" error
- [ ] E2E tests pass in CI with `NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN` secret configured

## Related
- Requires AcctAtlas-web-app#13 (Dockerfile ARG support)

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)