### PR TITLE
docs: replace Google Maps with Mapbox and update service statuses

### DIFF
--- a/docs/01-SystemOverview.md
+++ b/docs/01-SystemOverview.md
@@ -14,7 +14,7 @@ AccountabilityAtlas is a geo-located video curation platform focused on constitu
 ## Core Features
 
 ### Map-Based Video Discovery
-- Interactive Google Maps integration displaying thousands of geo-located YouTube videos
+- Interactive Mapbox integration displaying thousands of geo-located YouTube videos
 - Clustering for high-density areas
 - Pan, zoom, and location-based browsing
 - Video preview on marker selection

--- a/docs/02-TechnicalRequirements.md
+++ b/docs/02-TechnicalRequirements.md
@@ -123,7 +123,7 @@ Security controls scale with deployment phase:
 ### External Services
 | Service | Purpose | Integration Type |
 |---------|---------|------------------|
-| Google Maps Platform | Map display, geocoding | JavaScript SDK, REST API |
+| Mapbox | Map display, geocoding, places autocomplete | Mapbox GL JS SDK, REST API |
 | YouTube Data API | Video metadata, thumbnails, validation | REST API |
 | Amazon SES | Transactional email | REST API |
 | OAuth Providers | Google, Apple login | OAuth 2.0/OIDC |

--- a/docs/03-ArchitectureOverview.md
+++ b/docs/03-ArchitectureOverview.md
@@ -16,8 +16,8 @@ AccountabilityAtlas follows a **microservices architecture** with the following 
 │                              EXTERNAL SYSTEMS                                │
 ├─────────────────────────────────────────────────────────────────────────────┤
 │  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐     │
-│  │   YouTube    │  │ Google Maps  │  │    OAuth     │  │    Email     │     │
-│  │   Data API   │  │   Platform   │  │  Providers   │  │   Service    │     │
+│  │   YouTube    │  │   Mapbox     │  │    OAuth     │  │    Email     │     │
+│  │   Data API   │  │  Platform    │  │  Providers   │  │   Service    │     │
 │  └──────────────┘  └──────────────┘  └──────────────┘  └──────────────┘     │
 └─────────────────────────────────────────────────────────────────────────────┘
                                       │

--- a/docs/04-ServiceCatalog.md
+++ b/docs/04-ServiceCatalog.md
@@ -6,10 +6,10 @@
 |---------|------|------------|--------|
 | api-gateway | 8080 | /AcctAtlas-api-gateway | In Progress |
 | user-service | 8081 | /AcctAtlas-user-service | In Progress |
-| video-service | 8082 | /AcctAtlas-video-service | Planned |
-| location-service | 8083 | /AcctAtlas-location-service | Planned |
-| search-service | 8084 | /AcctAtlas-search-service | Planned |
-| moderation-service | 8085 | /AcctAtlas-moderation-service | Planned |
+| video-service | 8082 | /AcctAtlas-video-service | In Progress |
+| location-service | 8083 | /AcctAtlas-location-service | In Progress |
+| search-service | 8084 | /AcctAtlas-search-service | In Progress |
+| moderation-service | 8085 | /AcctAtlas-moderation-service | In Progress |
 | notification-service | 8086 | /AcctAtlas-notification-service | Planned |
 | web-app | 3000 | /AcctAtlas-web-app | In Progress |
 
@@ -275,7 +275,7 @@ LocationStats (separate table — counters change frequently, not temporal)
 ### Dependencies
 - PostgreSQL + PostGIS (spatial data)
 - Redis (cluster caching)
-- Google Maps Geocoding API
+- Mapbox Geocoding API
 
 ---
 

--- a/docs/05-DataArchitecture.md
+++ b/docs/05-DataArchitecture.md
@@ -685,7 +685,7 @@ Value: {
 }
 TTL: 2592000 (30 days)
 
-Note: Geocoding results rarely change; long TTL reduces Google Maps API costs.
+Note: Geocoding results rarely change; long TTL reduces Mapbox API costs.
 ```
 
 **Reverse Geocoding Cache**

--- a/docs/09-CostEstimate.md
+++ b/docs/09-CostEstimate.md
@@ -16,7 +16,7 @@ This document provides monthly cost estimates for AccountabilityAtlas infrastruc
 | 2 | Growth | ~$525 | ECS Fargate + ALB + ElastiCache |
 | 3 | Scale | ~$2,335 (+ ~$570 staging) | OpenSearch + WAF + Multi-AZ |
 | 4 | Full Prod | ~$2,370 (+ ~$570 staging) | Auto-scaling + DR (~$1,825 with RI) |
-| — | External APIs | ~$25 | Google Maps (all phases) |
+| — | External APIs | ~$0 | Mapbox free tier (all phases) |
 
 *All phase estimates include 20% buffer except Phase 1 (exact pricing). See each phase section for detailed breakdowns.*
 
@@ -77,17 +77,17 @@ This document provides monthly cost estimates for AccountabilityAtlas infrastruc
 
 ## External API Costs
 
-### Google Maps Platform
+### Mapbox
 
 | API | Free Tier | Unit Price | Estimated Monthly Usage | Cost |
 |-----|-----------|------------|-------------------------|------|
-| Maps JavaScript | $200 credit | $7.00/1K loads | 10K loads | $70 - $200 credit = $0 |
-| Geocoding | $200 credit | $5.00/1K requests | 5K requests | $25 |
-| Places Autocomplete | $200 credit | $2.83/1K requests | 2K requests | $6 |
+| Map Loads (Mapbox GL JS) | 50K/month free | $5.00/1K loads | 10K loads | $0 (within free tier) |
+| Geocoding (forward + reverse) | 100K/month free | $0.75/1K requests | 5K requests | $0 (within free tier) |
+| Search Box sessions | 1K/month free | $0.10/session | 500 sessions | $0 (within free tier) |
 
-**Note**: Google provides $200/month free credit. Light usage stays within free tier.
+**Note**: Mapbox provides generous free tiers. At current usage levels, all map-related API costs are $0/month. Costs only begin when usage exceeds free tier thresholds.
 
-**Estimated**: ~$25/month
+**Estimated**: ~$0/month (Phase 1-2), review at Phase 3+ scale
 
 #### Caching Strategy (Implemented)
 
@@ -98,7 +98,7 @@ Per [05-DataArchitecture.md](05-DataArchitecture.md), external API responses are
 | `extapi:geocode:{hash}` | 30 days | Same address lookups hit cache, not API |
 | `extapi:reverse:{lat}:{lng}` | 30 days | Same coordinate lookups hit cache |
 
-**Impact**: Caching ensures API costs remain stable (~$25/month) even as user traffic increases significantly. Without caching, costs would scale linearly with usage and quickly exceed the free tier.
+**Impact**: Caching ensures API costs remain within free tiers even as user traffic increases significantly.
 
 ### YouTube Data API
 
@@ -217,12 +217,12 @@ Unchanged from Phase 3: **~$570/month**
 
 | Phase | Monthly | Annual | Notes |
 |-------|---------|--------|-------|
-| Phase 1 (Year 1) | ~$187 | ~$2,244 | Incl. ~$25 external APIs |
-| Phase 1 (After Year 1) | ~$204 | ~$2,448 | Incl. ~$25 external APIs |
-| Phase 2 | ~$550 | ~$6,600 | Incl. ~$25 external APIs |
-| Phase 3 | ~$2,930 | ~$35,160 | Prod + staging + APIs |
-| Phase 4 (On-Demand) | ~$2,965 | ~$35,580 | Prod + staging + APIs |
-| Phase 4 (Reserved) | ~$2,420 | ~$29,040 | Prod + staging + APIs |
+| Phase 1 (Year 1) | ~$162 | ~$1,944 | Mapbox free tier covers API usage |
+| Phase 1 (After Year 1) | ~$179 | ~$2,148 | Mapbox free tier covers API usage |
+| Phase 2 | ~$525 | ~$6,300 | Mapbox free tier covers API usage |
+| Phase 3 | ~$2,905 | ~$34,860 | Prod + staging, review Mapbox usage |
+| Phase 4 (On-Demand) | ~$2,940 | ~$35,280 | Prod + staging |
+| Phase 4 (Reserved) | ~$2,395 | ~$28,740 | Prod + staging |
 
 **Savings with Reserved Instances (Phase 4)**: ~$6,500/year (18%)
 
@@ -248,7 +248,7 @@ Unchanged from Phase 3: **~$570/month**
 | Service | Account Required | Payment Method |
 |---------|------------------|----------------|
 | AWS | AWS Account | Credit card or invoicing |
-| Google Cloud (Maps) | Google Cloud Project | Credit card |
+| Mapbox | Mapbox Account | Credit card (free tier available) |
 | Google OAuth | Google Cloud Console | Free |
 | Apple OAuth | Apple Developer Account | $99/year |
 | GitHub | GitHub Organization | Free (public) or $4/user/month |


### PR DESCRIPTION
## Summary
- Replace all Google Maps references with Mapbox across 6 documentation files
- Update service catalog statuses from "Planned" to "In Progress" for video-service, location-service, search-service, and moderation-service
- Update cost estimates to reflect Mapbox free tier pricing ($0/month for current usage vs ~$25/month for Google Maps)

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)