### PR TITLE
fix: improve fetch_youtube.py reliability and rate-limit handling

### DIFF
--- a/scripts/extract-metadata/fetch_youtube.py
+++ b/scripts/extract-metadata/fetch_youtube.py
@@ -318,7 +318,7 @@ def _fetch_all(
             if _is_rate_limited(e):
                 remaining = len(urls) - i
                 print(
-                    f"\n  Rate limited by YouTube (HTTP 429). Stopping.",
+                    "\n  Rate limited by YouTube (HTTP 429). Stopping.",
                     file=sys.stderr,
                 )
                 print(
@@ -326,7 +326,7 @@ def _fetch_all(
                     file=sys.stderr,
                 )
                 print(
-                    f"  Wait for the rate limit to clear, then re-run with --append.",
+                    "  Wait for the rate limit to clear, then re-run with --append.",
                     file=sys.stderr,
                 )
                 errors.append(f"Rate limited at video {i}/{len(urls)}: {url}")

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,3 +4,4 @@ sonar.organization=kelleyglenn
 
 sonar.sources=scripts
 sonar.exclusions=**/requirements.txt,**/*.md,**/__pycache__/**
+sonar.python.version=3.12


### PR DESCRIPTION
## Summary
- Let yt-dlp handle subtitle downloads via `download=True` + temp dir so cookies and rate-limit handling apply to subtitle fetches
- Stop immediately on 429 rate limiting instead of continuing to fail on every subsequent URL
- Add `--cookies-from-browser` flag for authenticated YouTube sessions (~6x higher rate limits)
- Add `--delay` flag for inter-video throttling
- Write output incrementally so `--append` can resume after interruption
- Remove unnecessary `format: "best"` that caused errors on some videos

Closes #87

## Test plan
- [x] Verified script fetches metadata + transcripts successfully with `--cookies-from-browser firefox --delay 5`
- [x] Verified `--append` correctly resumes after interruption
- [x] Verified graceful handling of videos without transcripts (warning, continues)
- [x] Verified rate-limit detection stops the run with a clear message
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)